### PR TITLE
Minor changes with pdf codec and a small eyeball test for planned enhancment

### DIFF
--- a/modules/s3/s3codecs/pdf.py
+++ b/modules/s3/s3codecs/pdf.py
@@ -259,8 +259,7 @@ class S3RL_PDF(S3Codec):
             response.headers["Content-Type"] = contenttype(".pdf")
             response.headers["Content-disposition"] = disposition
 
-        doc.output.seek(0)
-        return doc.output.read()
+        return doc.output.getvalue()
 
     # -------------------------------------------------------------------------
     def get_html_flowable(self, rules, printable_width):
@@ -1243,17 +1242,19 @@ class S3html2pdf():
         from reportlab.platypus import Image
 
         I = None
+        sep = os.path.sep
         if "_src" in html.attributes:
             src = html.attributes["_src"]
+            root_dir = "%s%s%s" % (sep, current.request.application, sep)
             if uploadfolder:
-                src = src.rsplit("/", 1)
+                src = src.rsplit(sep, 1)
                 src = os.path.join(uploadfolder, src[1])
-            elif src.startswith("/%s/static" % current.request.application):
-                src = src.split("/%s/" % current.request.application)[-1]
+            elif src.startswith("%sstatic" % root_dir):
+                src = src.split(root_dir)[-1]
                 src = os.path.join(current.request.folder, src)
             else:
-                src = src.rsplit("/", 1)
-                src = os.path.join(current.request.folder, "uploads/", src[1])
+                src = src.rsplit(sep, 1)
+                src = os.path.join(current.request.folder, "uploads%s"%sep, src[1])
             if os.path.exists(src):
                 I = Image(src)
 

--- a/modules/tests/run_pdf_tests.py
+++ b/modules/tests/run_pdf_tests.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Needs to be run in the web2py environment
+# python web2py.py -S eden -M -R applications/clean/modules/tests/run_pdf_tests.py
+
+import os
+from gluon import *
+from gluon.storage import Storage
+from s3.s3rest import S3Request
+from gluon.contrib.pdfinvoice import PDF
+
+WRITE_PDF = True
+
+def header(r):
+    img_path = os.path.join(current.request.application,
+                        "static", "img","sahanalarge_14.png")
+    html_h = TABLE(TR(TD(IMG(_src=os.path.sep+img_path)),
+                      TD("A lovely Title"),
+                      TD(DIV(P("Right aligned text"),P("<i>not yet implemented</i>")),_align="right")),
+                     TR(TD("This is a test header. These details should be" +
+                         " displayed on every page. This dull and meaningless" +
+                         " text should stretch across the entire page," +
+                         " and then wrap around onto a second line.",_colspan=3)
+                      )
+                   )
+    return DIV(html_h)
+def footer(r):
+    return P("A footer that will appear at the end of each page.", _halign="center")
+def body_1(r):
+    # Here is some hard-coded test data
+    name = "Mr. Administrator, Sir"
+    org_name = "Example"
+    email = "admin@example.com"
+    logo_path = os.path.join(current.request.application,
+                        "static", "img","blank-user.gif")
+    innerTable = TABLE(TR(TH(T("Name")), TH(T("Organisation")), TH(T("Email"))),
+                       TR(TD(TD(name),TD(org_name),TD(email)))
+                       )
+    person_details = TABLE(TR(TD(IMG(_src=os.path.sep+logo_path)),
+                              TD(innerTable)
+                              ))
+
+    todo = DIV(P("So here is a list of features that could be added."),
+               LI("Extend basic html tag support: H1, H2, etc, LI, etc"),
+               LI("Add support for standard attributes: align, halign, valign"),
+               LI("Make the header and footer fit on a landscape page if the table changes the page layout"),
+               LI("Be able to control the width of table cells, being more smart about this would be good, but probably harder to implement. See the above tables the cells in the heading are all the same width. The inner table overflows the outer table."),
+               )
+    
+
+    # Now put all the output together
+    output = DIV(H1("<b><h1>Here is an example of hardcoded data, created via a callback function which returns html.</h1></b>"),
+                 P("<i>Unfortunately, the header tags don't yet work these can be added in the s3codecs/pdf.py file</i>"),
+                 TABLE(TR(TH(T("Volunteer Service Record")))),
+                 person_details,
+                 todo,
+                 )
+
+    return output
+
+def test_pdf1():
+    """
+        Generate a Test PDF that will demonstrate S3RL_PDF functionality
+    """
+    r = S3Request(prefix="pr", name="person")
+    T = current.T
+    from s3.s3export import S3Exporter
+    exporter = S3Exporter().pdf
+    return exporter(r.resource,
+                    request = r,
+                    method = "list",
+                    pdf_title = T("PDF Test Card I"),
+                    pdf_header = header,
+                    pdf_callback = body_1,
+                    pdf_footer = footer
+                    )
+
+def test_pdf2():
+    """
+        Generate a Test PDF that will demonstrate S3RL_PDF functionality
+    """
+    r = S3Request(prefix="gis", name="hierarchy")
+    from s3.s3export import S3Exporter
+    exporter = S3Exporter().pdf
+    return exporter(r.resource,
+                    request = r,
+                    method = "list",
+                    pdf_title = T("PDF Test Card II"),
+                    pdf_table_autogrow = "B",
+                    pdf_header = header,
+                    pdf_footer = footer
+                    )
+
+pdf = test_pdf1()
+
+if WRITE_PDF:
+    filename = os.path.join("applications", current.request.application,
+                        "modules", "tests", "test_pdf_1.pdf")
+    f = open(filename, 'wb')
+    f.write(pdf)
+    f.close()
+
+pdf = test_pdf2()
+
+if WRITE_PDF:
+    filename = os.path.join("applications", current.request.application,
+                        "modules", "tests", "test_pdf_2.pdf")
+    f = open(filename, 'wb')
+    f.write(pdf)
+    f.close()
+

--- a/modules/tests/test_pdf_1.pdf
+++ b/modules/tests/test_pdf_1.pdf
@@ -1,0 +1,156 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+% 'BasicFonts': class PDFDictionary 
+1 0 obj
+% The standard fonts dictionary
+<< /F1 2 0 R
+ /F2 4 0 R
+ /F3 5 0 R >>
+endobj
+% 'F1': class PDFType1Font 
+2 0 obj
+% Font Helvetica
+<< /BaseFont /Helvetica
+ /Encoding /WinAnsiEncoding
+ /Name /F1
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'FormXob.437d014c666215218411a11c3a150714': class PDFImageXObject 
+3 0 obj
+<< /BitsPerComponent 8
+ /ColorSpace /DeviceRGB
+ /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Height 178
+ /Length 3351
+ /Mask [ 255
+ 255
+ 255
+ 255
+ 255
+ 255 ]
+ /Subtype /Image
+ /Type /XObject
+ /Width 179 >>
+stream
+Gb"/lc#GNu%#4(=%B1OGUl?(NR@MaJ=,65^+$>a.9(9f_UMhSY'S!=e#nZ#IhVi]i>@(7HZS+T3htOV'j`7n:/sjcCEk,F-QcnK2\QgbRbN3cT>V=WY5!QE$i3K<)It)0V_.?E7+(,'Im\\scFL-lE(iC7p(O^`80\eKi0A>tfBKN*MfUPO\0(r$"p+'e9,YIF_a[Z0P%`V))fu8tcCt4?JTrD1I?Nm4D`pM"p?oVk69q")no#NF#m!\J>11#$&'j>cXB4K+0,,X=ZJ_"]-YQ+MM]<KYjMj[sD=O<3'q/HK]1nf4+[YpZ8KF6"$52bMTg)6-*&K89.mo#:"O\rs6lI-SUBOtT@Aep>24SRsS/pP0V_!bZmF;qBGNI,7T'[A>*Bp;RNA<XqE*=S*7@#S:pSr.amV%,t=+'oVWK0`DV^\hnElp:i6U3uf?6+P?o_<=WE<%7l+3l#EW.-btNXkK@HB*04u\m5;r6,Ra?f<%ir0g+V6%Lc6=l*H;qCpK>0n4+<9X&B<6#*t6$],1SOJV4i3A5U.Pmrr0,n7rgkAOcH==K5YOdD:?\A&'^?9OkTq%L,p40EBuIZjSE%@"miQ4>jQbg]p<f2hp]$"U<fB:(>4YH'3U9>d?)%(V=5_VT<R2[UZ^\l#EeuK95Mpc:4:W$36"s.aADkEQf>>,9ru^*,pp#!e<#XaYSPM*M<NA@2X-h4ApdY;.iqaR8<2P<gA4>JakJX6D=ek$Pb#o"#(2"5e':T*=OR(\:\d5iP<P(?lXQ#2L%<\*?/imfEc^Um[/r@0N)mRF6+9."G8i?/7@sjl$Dn%,AK"8/MP2t@.0//E>R"ZfOJ>!%)E!T[0uSK_&-TJ_Cbs!N7G]dR>)_9,cJ5qjcOMoL:*fd7NWR9h2iK1d,Dt1@[#fiU^mkW]AVJD\&8k?]UiC3;+s>*.-abcfYulQjJ=gQ[%^k(PW^_;:Yu-NXo,:t#:cuO!hJFO;U_q0$chqQ\mX:n\@&e1J,SoX00m._iRT2),'MAdj[Yc*?!QA`F@SBB2@[ZS('=Z_#o=lR0W<_pM!5;;^"70t"(RFJZ45e:_1T=)"C:M@9Ed@!SP@b!a:-!*)!WtkeHR\VZT?L2d5V%k4:JgAJaFZ"F>q[fp)S(?=u;ph,3KT@k#=_TeP9,[877O"6(E.PYOP'Z'lR[r*@PbK*o]9S)Ujc_"eLL"!N+f^!SEJT+!Yq@1rhG7?m+&In2sYVl"3;)E"(DgO<r?e7=pE;WN"N\_)-<k#U:)*jHB@ooWX]T,#9(1NL<>!$BOdV&N#UZ.MZu3UhQYoaR'G2UL>s8UmdTG9MpB2%66=K%V:Mj__cn"bb64jUX^H[EEIaKT]p:"O:WuqJ:mu#H<r'ZbtKPN8VH.D]Er.$.Y?fen_TY*VG#]!?LPjRpIOr"c,QqP2ISG%'rgu-.1$.ps74eI19AR#^l+G:ZA1!.YppJS_JB3qOlhem=;X698-Z)Q!PU:+)J`7`,frMkfW.uY^(.lUI_0A6h<S?^bY4.^@A@"L;Q1MZ,;%On9]J*'6j^(pbp+YSfa_=XXnCH8D69F?[K)]7H&X!]2]Kh#dX$lR#"Aau'jqsT&i;ZR:-4O=@QdL.@i*Wqon8Gc1,f6ZD`f9d/8UPr,`@8Femd[A?"P3TIm"nqHYK>FbWW:3ZqR6bS)>rpGerE2K[eEWr[crIODR#_O@ju/cR80(jEPp2GQ85Z>=/J0`]JDc9##qYY(8YkQ=-L5Y7:XB(o)=,84^dD6Q!ilUL<%reibK"TlmTE&g!+F@K[!r@oPHcGu=8blS/;_pK<8o6MQYPets_Wrg:CMEf#s1dP4:#nDI_FX@SEmUDg"D06Z`W%u_)YXFMIH6jnrofZRXHI"CNj*uKEBR%QbYM(0@Eh%L'XFK>E,m"bAqZeAHS@ebdf&rpCrNQb#+X[<t_=ZjW'[:T$X;o)iZ$@iS*._rZbLo(SC(e_*LmMIN6VA[?`6g+Nf4r$DEOg-W*G?A?bFiW^;OoT;l7`$JklB**o$[+5,e`W2n;stsS-\/If@rN/"VV"]o34%2IW5N9]/MIU<@3_nUCDmh2,\ri!(u!QG$3k(21HlW*];]HqAV?p%@[hOLKT5dXT<YM3)O#rtaMR^_pK4I!SST+Il'A)JGcYHp6F0Wbdq9n=+sH71[VQao;_C'caUeM\QtES%;t4D9Liih8<u=dh\:XI>Yb+`+P=R^$<nQ&O*6I-8XPrbSB#>)nZ0ATGGXr8O(g!cWL63`Z2T:g]Gu>go'fO`!kS6)sPHBK.1b2$Lir-&3[("Y6*N3J@%u(]3VL5.]CD:n.Y4LsTb%'m._,+bhA<?6)bPB%TMkKYa9gr`!3Fs"`3LkcIlC879`PXMdY1$%(0EE'h>hNbKnSPre*Ra*a96JeN'm$=@C`Vbhb1dWnPs_!H>#<%s`Zq%<8q?GCB<AI8ZR-oF@)V-CRlIF9h+aZI]o1LLW*h?A\*]3KE67:?Z(p$JgPp_\eu5_*S%LoP%?&o(K@)'9@.6&t0Fj7?Wa`Q7\9d@=*94i3E<a#dA`K.cn3):e4nMp<nYLHkZCG%`_Di8d^c7]q0\OE6p%g!C?lZ6N*OL_tEYhXZ6T^ZOlCd.uOO1&X6Ou,YN!ZkDA.r2\!D(;-*r9.r\CU21C`7.?n0DOR&*4UCDW4s^4fW57_-oE0JGYWrTmM`&@m;Yh820g7)HdLX3BT8ko`/G),9:Do0I6-ihDBJr#=^VsdZ+p`P7``uPb<u@%0h3+;Wp=i*c;ll0nE1BB5oV7*1<BmlsMrp!<t7-K:Bi3nb=XDCq,):^joAWAaE0$A2#'saA%:Q116p:P61n:(OP]A&i?OKE4a"Lc3=UaGR*]S_bK1'(CWD@@Fh(U7M)g]Fjp+$!2CUF/iJfXeR1TkH=DfomEhSZ6-:>7n9,@fs3!Pfa?b2id'F$$;S4^\>'"&Jh^L_e>>?l0c.:Q-\+!deW@6dq9IT"po<XQq4PTkW9`kJ%1,!-,Q,I+mmi-)54GXX(N>/[ia%$KY#%ZjR4@D[%`.Gm[XQ2Io(5BX"Y-?l^_5e=gBk>"o)W[G*;/DoJ^T8o(nYljb2TRQhSU9cG)q]F%;Dbt!0WG8N**rW(&O2&W(i@.b^k;,(/l68(RL;3(Vl"[-3DaPaX<^oXMqV#B6N]"9Z.m6'm6]<hQul=[.S<^I$.naCK4.MZ:bXUU_;Lgq1tWZ!VJATpV#4D.";5r\U`GC?oa4/2JTm8ZR3/t?;!#c.Qm)#p">Vl_MQqgea^qgQ*skUO;`5VS2>"s:dd`2.=C8:96Q6juK(W7$E%k>?"M;/o\s$n59g)=\YqbKm\HXqiYs)KD\m-kSbN3cT>V;Adj`7n:2YB:^"hYT~>endstream
+endobj
+% 'F2': class PDFType1Font 
+4 0 obj
+% Font Helvetica-Oblique
+<< /BaseFont /Helvetica-Oblique
+ /Encoding /WinAnsiEncoding
+ /Name /F2
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'F3': class PDFType1Font 
+5 0 obj
+% Font Helvetica-Bold
+<< /BaseFont /Helvetica-Bold
+ /Encoding /WinAnsiEncoding
+ /Name /F3
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'FormXob.f79e432cfa7e02b758b1d1b47ae36448': class PDFImageXObject 
+6 0 obj
+<< /BitsPerComponent 8
+ /ColorSpace /DeviceRGB
+ /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Height 100
+ /Length 1586
+ /Subtype /Image
+ /Type /XObject
+ /Width 100 >>
+stream
+Gb"/kBiF"b'SZSe?^Y=S_NH#aZAoL5R]m'l-mDk,`6#4tmk&t.@V-Sb8U'&;k,Iss07AjPpV!,8FupW^)]K_8)]K`cc]1&WhXl,:7?Ipdmeg9IP7dDsEiIQ&[jRp_p?2q$r*e/k2R;R(+6$QYf9`[JJ!7e/#R5nm?2LAhrVI9%GS-<<`g(R)(6,o]mQ^==Rf\.k/Bcf8#(--(=T-U(P4[l]FJ,@jaCf`J#Q;@Z#Y1fb.Z_VsfkFs.Tnjo9:?V/.dr0hp%,OKj:K/1eh\-F`<TR[%gDOGNlW*$,KQp>na&OTtq]e\7>+lY[M_$Z.6$_sn_Vb]>*+t8Z$gK.?62c2<3nQn.O@gi;A<f`_Y`7oOC2>'teN`0eq98gV0'759a29#Md,"(@[U!0(U!=u5OBehpgXV"Pa:,DT@b]Fe,Sf[I%]!.!>D660X(J-P/1W.0YjL]W8jm8o'dX1@XtHlh?"R4S6kS1V/m)^c1AUnXbH*="9l.GQkd9*gZF]=EZ0ghN;CXEEWcrlFD-%OAFP;2H%Um!*KYq51=ga\-CraRP*Y'2#-aTnIT>Gc!4OEjZ$OUtkO(178Sl/EpR2+oF1ekkGI3^?_S1i2q=3^X0I\s,?-bK2sj`8TfB%WuAAA-[c+eDh;Hml@.YHU_C:Q=?*Sk:?7mHOaFXEZkQ-7cFk?gXF\mWlKPg-PQ5rl;tZgFE;fM$2A%T].hU1\aSKd@cq.g>k'?4qFYcp%X;RcH3^1M*r`q"oebtQ;qiimg'^,(U2-rL>JMS`Qn/DSnn*t-q$0GLVkjX^W/6&Sq8@'cO+tHpb-#:,L9mW,/+u41l-",(/f_EUZM#j(\9Yq-X&VaQ^j*]Q.<?[(>BC+8Cd46WXc-jX7$-hE?Gh>T9[4`fN))cMam(Mn3Df"iiXd=[LX.0q4.GcqDU@c5$.fgO8c5`c2:$05TU^L,28nnoC!Or'1F6hMVA3!9&<(e1f>@$cf^cm`n6#Z!WCp_d2SFg?uVu<Z#,W$eSMbOj=fX\>S!ilD2oGeR1i`uhMH$pmpiuZbAt.HeV[b@r&6o[=HoW3%oXO4JWso7$HH">BjZH7FP7NX3n!MNOj^u=&DsG<%=[bDSW&J)!AUF!"Te]r.ZB-Mlr8FB]A;97HI*/fq2#q\Jr)#sM*RDe^3p=rS>+(+cf.!l:-hqbFaifUMZ*G`caK4e6fj7J_FFb5#-=2.N_2W^+-4HFSnt2G(k4(TD)N<U7k2Q@?rA2ST4o]nS=f-W!iV"&=Im](d:k-i]H??2BfNUq-5*POT\H.lW;OV^md[7;&nZ&a3#nP5V0tXL=Ka4sqE7*S<i,c<6:TNt3./f(b115qF\fe@K$!2H,B3.M.(.NJAsD3A*t@-&[!d.FCQMTB;#572)JTZ_G&mkM+:,0A&M/4"TdnEap-n9n.jA>OXf^CSq<n%pGDVhnZ*k9XB93kXp?3_U^7aJ;!k#0ZkT_grTQng?:!DeJ7q-kVh4E_KR80U*7q-j3B0B1kVl-HV,;FlVrB@nF72Ahrnl"E!h;'usRZ0@f4#3+$[9O1GKBU3,KaM;G0%ph82Nq]kLrC9a2TLd66W(dWq#:?2(7bX~>endstream
+endobj
+% 'Page1': class PDFPage 
+7 0 obj
+% Page dictionary
+<< /Contents 11 0 R
+ /MediaBox [ 0
+ 0
+ 595.2756
+ 841.8898 ]
+ /Parent 10 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R
+ /FormXob.f79e432cfa7e02b758b1d1b47ae36448 6 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'R8': class PDFCatalog 
+8 0 obj
+% Document Root
+<< /Outlines 12 0 R
+ /PageMode /UseNone
+ /Pages 10 0 R
+ /Type /Catalog >>
+endobj
+% 'R9': class PDFInfo 
+9 0 obj
+<< /Author (\(anonymous\))
+ /CreationDate (D:20150103103453-03'00')
+ /Creator (\(unspecified\))
+ /Keywords ()
+ /Producer (ReportLab PDF Library - www.reportlab.com)
+ /Subject (\(unspecified\))
+ /Title (PDF Test Card I 2015-01-03 10:34:52) >>
+endobj
+% 'R10': class PDFPages 
+10 0 obj
+% page tree
+<< /Count 1
+ /Kids [ 7 0 R ]
+ /Type /Pages >>
+endobj
+% 'R11': class PDFStream 
+11 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1580 >>
+stream
+Gatm;h/hR6&:\>Is'afRhJeM:Dr4K7dp1AI>s"D":1&],@pNooQ";rSqlXIg+X(6,-O`CHXnG-ZnQQ&QrXnamPQ2fgE;PIlEF>@=nLP45TAb5_Sbt:7OR62+=9/PEBLPc<+kLgF)i@lq-U#4]pmiYb!P#:@_S+=$4PTI:6OKBd(=UCm-R$[J`PV3$0XZb("@:rWh]\+P#ULa9.IleeGjr&,:;31CSd5t`QL4GW`&gNq)NpZ=0$Ht`E'3?2EsID$Z!mfVXpXkIbeM!lSMB/i,WG?HgUFjH,sCg1Y(.:8=g8YTql[q1Mo[klc@N>p.+g3W]W;KAZ:_CoUc<b$1Lc/ibc5s6)o)tQM])aZUFDBBb]D>h8=?3bBV<I9>GSL=*T#9Lh4Oj<"`20=#&:_[RK5'5gS+[OV,/pNnS242VD4\-DePAG.`m5g;J8tR!);KopM`(f[[FZ.M&!*<Xas*l<a)41W+X!\JZFB(b^./Q^Zhq?du!2@,Rt*mr-eK3dpP>0<8''M"=<iWA(dOtQt6:o*R3H=fSB@trmADHDr'LrOPJZ/Qmc5EQijtN*j6MN>qDBW]@H>fX(X1imfqAi<$m9-')bT@XLWf-\n4nC0"VA+VoXBcHq3f%-f_M55ES1[T<nC(#PpP:a\74o]R?\=)mo7-ats\Z`aMISSO"G;`>!k<V\gTa/W'^+SfqmM6u`XcFj<ii%),bC%HON?`i'oh(T;bL^OK:POK,EZX(!k@NpC]n'O>1FM!BaJ_:M";CGMbkJi7(ud8\l>/&TlHg<?A'XjbLo2j!Pc<Nag+hfH:B3MGVGoY:1OL7%asL8]K\$hSZ:mT#luch*&M:3-3?h7r(602])Yg<_?G9WiWWi"<;"^/aGNbj30R*hV!GP58_?q;M"[G%e:%2VBX?RHHV&7RLcLMpRM#,UEgOUs'91007s#SHs@^_al_;0d..%nC[;/cb4igc*TWpS=&Y/1nKg4^-uMK8I2TBIu-M<^FBYAVrd0=6Becr='ko^>[fd2W3/N9`K6/u='R3;^;Opf>/3S#pQiVa=KhKDG?+:t/hK(%W?bJ1c?@r<>`S>*hL@tt]'gQS.%afnJSM67g,:!&&`s$jR0$YiS1q0P9\A8l!UBDdeYV6_E9-dOT!Lr&`Km`&;9^t/CC`b?=_Jr!OHD1(h.:ba#8K3<?%KmL'mQBe,>DV4?""N-kmAG9Jjp71iCRDrhZ=FDTSSsIN+@`->033C1*o(a2LTrUbjbR(@)g@u:`>BHBYtJcCG`\SVQFW%+!9Elbi$=*!J9_WI/_[o1I<7G>cl@YReG_Q84l;JLuf5M+aR+N03Xl$5'00A$pe.m]/%,GoQ&rlp%h"Ifffbl'?1gOAmFS7#2^(QRtTA:i*,',@8M&sQnuiu[:J+7@]26iM>$QIfI:ZuMRMQofgguF/KG'<*.!h`Ki)7&;jH[igZle9U7#H2iQ)2!_!l/4MZ0L]e.<KO=P%st/qljd..5\b/<G9iYdDEH@Mh!T`+,@Mn;c$QSJc^D'9(9ZV.uoCi=oiJp?n"m2UtQ$1JZrWb+N+D1#=@c6EIf":s5GN,[Fe=q%ntOp.b~>endstream
+endobj
+% 'R12': class PDFOutlines 
+12 0 obj
+<< /Count 0
+ /Type /Outlines >>
+endobj
+xref
+0 13
+0000000000 65535 f
+0000000113 00000 n
+0000000233 00000 n
+0000000439 00000 n
+0000004074 00000 n
+0000004255 00000 n
+0000004471 00000 n
+0000006293 00000 n
+0000006687 00000 n
+0000006823 00000 n
+0000007115 00000 n
+0000007222 00000 n
+0000008947 00000 n
+trailer
+<< /ID 
+ % ReportLab generated PDF document -- digest (http://www.reportlab.com) 
+ [(\232\371\002\255\237\323\276\234\215Q\321&\217\243P1) (\232\371\002\255\237\323\276\234\215Q\321&\217\243P1)] 
+
+ /Info 9 0 R
+ /Root 8 0 R
+ /Size 13 >>
+startxref
+8999
+%%EOF

--- a/modules/tests/test_pdf_2.pdf
+++ b/modules/tests/test_pdf_2.pdf
@@ -1,0 +1,364 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+% 'BasicFonts': class PDFDictionary 
+1 0 obj
+% The standard fonts dictionary
+<< /F1 2 0 R
+ /F2 4 0 R
+ /F3 5 0 R >>
+endobj
+% 'F1': class PDFType1Font 
+2 0 obj
+% Font Helvetica
+<< /BaseFont /Helvetica
+ /Encoding /WinAnsiEncoding
+ /Name /F1
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'FormXob.437d014c666215218411a11c3a150714': class PDFImageXObject 
+3 0 obj
+<< /BitsPerComponent 8
+ /ColorSpace /DeviceRGB
+ /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Height 178
+ /Length 3351
+ /Mask [ 255
+ 255
+ 255
+ 255
+ 255
+ 255 ]
+ /Subtype /Image
+ /Type /XObject
+ /Width 179 >>
+stream
+Gb"/lc#GNu%#4(=%B1OGUl?(NR@MaJ=,65^+$>a.9(9f_UMhSY'S!=e#nZ#IhVi]i>@(7HZS+T3htOV'j`7n:/sjcCEk,F-QcnK2\QgbRbN3cT>V=WY5!QE$i3K<)It)0V_.?E7+(,'Im\\scFL-lE(iC7p(O^`80\eKi0A>tfBKN*MfUPO\0(r$"p+'e9,YIF_a[Z0P%`V))fu8tcCt4?JTrD1I?Nm4D`pM"p?oVk69q")no#NF#m!\J>11#$&'j>cXB4K+0,,X=ZJ_"]-YQ+MM]<KYjMj[sD=O<3'q/HK]1nf4+[YpZ8KF6"$52bMTg)6-*&K89.mo#:"O\rs6lI-SUBOtT@Aep>24SRsS/pP0V_!bZmF;qBGNI,7T'[A>*Bp;RNA<XqE*=S*7@#S:pSr.amV%,t=+'oVWK0`DV^\hnElp:i6U3uf?6+P?o_<=WE<%7l+3l#EW.-btNXkK@HB*04u\m5;r6,Ra?f<%ir0g+V6%Lc6=l*H;qCpK>0n4+<9X&B<6#*t6$],1SOJV4i3A5U.Pmrr0,n7rgkAOcH==K5YOdD:?\A&'^?9OkTq%L,p40EBuIZjSE%@"miQ4>jQbg]p<f2hp]$"U<fB:(>4YH'3U9>d?)%(V=5_VT<R2[UZ^\l#EeuK95Mpc:4:W$36"s.aADkEQf>>,9ru^*,pp#!e<#XaYSPM*M<NA@2X-h4ApdY;.iqaR8<2P<gA4>JakJX6D=ek$Pb#o"#(2"5e':T*=OR(\:\d5iP<P(?lXQ#2L%<\*?/imfEc^Um[/r@0N)mRF6+9."G8i?/7@sjl$Dn%,AK"8/MP2t@.0//E>R"ZfOJ>!%)E!T[0uSK_&-TJ_Cbs!N7G]dR>)_9,cJ5qjcOMoL:*fd7NWR9h2iK1d,Dt1@[#fiU^mkW]AVJD\&8k?]UiC3;+s>*.-abcfYulQjJ=gQ[%^k(PW^_;:Yu-NXo,:t#:cuO!hJFO;U_q0$chqQ\mX:n\@&e1J,SoX00m._iRT2),'MAdj[Yc*?!QA`F@SBB2@[ZS('=Z_#o=lR0W<_pM!5;;^"70t"(RFJZ45e:_1T=)"C:M@9Ed@!SP@b!a:-!*)!WtkeHR\VZT?L2d5V%k4:JgAJaFZ"F>q[fp)S(?=u;ph,3KT@k#=_TeP9,[877O"6(E.PYOP'Z'lR[r*@PbK*o]9S)Ujc_"eLL"!N+f^!SEJT+!Yq@1rhG7?m+&In2sYVl"3;)E"(DgO<r?e7=pE;WN"N\_)-<k#U:)*jHB@ooWX]T,#9(1NL<>!$BOdV&N#UZ.MZu3UhQYoaR'G2UL>s8UmdTG9MpB2%66=K%V:Mj__cn"bb64jUX^H[EEIaKT]p:"O:WuqJ:mu#H<r'ZbtKPN8VH.D]Er.$.Y?fen_TY*VG#]!?LPjRpIOr"c,QqP2ISG%'rgu-.1$.ps74eI19AR#^l+G:ZA1!.YppJS_JB3qOlhem=;X698-Z)Q!PU:+)J`7`,frMkfW.uY^(.lUI_0A6h<S?^bY4.^@A@"L;Q1MZ,;%On9]J*'6j^(pbp+YSfa_=XXnCH8D69F?[K)]7H&X!]2]Kh#dX$lR#"Aau'jqsT&i;ZR:-4O=@QdL.@i*Wqon8Gc1,f6ZD`f9d/8UPr,`@8Femd[A?"P3TIm"nqHYK>FbWW:3ZqR6bS)>rpGerE2K[eEWr[crIODR#_O@ju/cR80(jEPp2GQ85Z>=/J0`]JDc9##qYY(8YkQ=-L5Y7:XB(o)=,84^dD6Q!ilUL<%reibK"TlmTE&g!+F@K[!r@oPHcGu=8blS/;_pK<8o6MQYPets_Wrg:CMEf#s1dP4:#nDI_FX@SEmUDg"D06Z`W%u_)YXFMIH6jnrofZRXHI"CNj*uKEBR%QbYM(0@Eh%L'XFK>E,m"bAqZeAHS@ebdf&rpCrNQb#+X[<t_=ZjW'[:T$X;o)iZ$@iS*._rZbLo(SC(e_*LmMIN6VA[?`6g+Nf4r$DEOg-W*G?A?bFiW^;OoT;l7`$JklB**o$[+5,e`W2n;stsS-\/If@rN/"VV"]o34%2IW5N9]/MIU<@3_nUCDmh2,\ri!(u!QG$3k(21HlW*];]HqAV?p%@[hOLKT5dXT<YM3)O#rtaMR^_pK4I!SST+Il'A)JGcYHp6F0Wbdq9n=+sH71[VQao;_C'caUeM\QtES%;t4D9Liih8<u=dh\:XI>Yb+`+P=R^$<nQ&O*6I-8XPrbSB#>)nZ0ATGGXr8O(g!cWL63`Z2T:g]Gu>go'fO`!kS6)sPHBK.1b2$Lir-&3[("Y6*N3J@%u(]3VL5.]CD:n.Y4LsTb%'m._,+bhA<?6)bPB%TMkKYa9gr`!3Fs"`3LkcIlC879`PXMdY1$%(0EE'h>hNbKnSPre*Ra*a96JeN'm$=@C`Vbhb1dWnPs_!H>#<%s`Zq%<8q?GCB<AI8ZR-oF@)V-CRlIF9h+aZI]o1LLW*h?A\*]3KE67:?Z(p$JgPp_\eu5_*S%LoP%?&o(K@)'9@.6&t0Fj7?Wa`Q7\9d@=*94i3E<a#dA`K.cn3):e4nMp<nYLHkZCG%`_Di8d^c7]q0\OE6p%g!C?lZ6N*OL_tEYhXZ6T^ZOlCd.uOO1&X6Ou,YN!ZkDA.r2\!D(;-*r9.r\CU21C`7.?n0DOR&*4UCDW4s^4fW57_-oE0JGYWrTmM`&@m;Yh820g7)HdLX3BT8ko`/G),9:Do0I6-ihDBJr#=^VsdZ+p`P7``uPb<u@%0h3+;Wp=i*c;ll0nE1BB5oV7*1<BmlsMrp!<t7-K:Bi3nb=XDCq,):^joAWAaE0$A2#'saA%:Q116p:P61n:(OP]A&i?OKE4a"Lc3=UaGR*]S_bK1'(CWD@@Fh(U7M)g]Fjp+$!2CUF/iJfXeR1TkH=DfomEhSZ6-:>7n9,@fs3!Pfa?b2id'F$$;S4^\>'"&Jh^L_e>>?l0c.:Q-\+!deW@6dq9IT"po<XQq4PTkW9`kJ%1,!-,Q,I+mmi-)54GXX(N>/[ia%$KY#%ZjR4@D[%`.Gm[XQ2Io(5BX"Y-?l^_5e=gBk>"o)W[G*;/DoJ^T8o(nYljb2TRQhSU9cG)q]F%;Dbt!0WG8N**rW(&O2&W(i@.b^k;,(/l68(RL;3(Vl"[-3DaPaX<^oXMqV#B6N]"9Z.m6'm6]<hQul=[.S<^I$.naCK4.MZ:bXUU_;Lgq1tWZ!VJATpV#4D.";5r\U`GC?oa4/2JTm8ZR3/t?;!#c.Qm)#p">Vl_MQqgea^qgQ*skUO;`5VS2>"s:dd`2.=C8:96Q6juK(W7$E%k>?"M;/o\s$n59g)=\YqbKm\HXqiYs)KD\m-kSbN3cT>V;Adj`7n:2YB:^"hYT~>endstream
+endobj
+% 'F2': class PDFType1Font 
+4 0 obj
+% Font Helvetica-Oblique
+<< /BaseFont /Helvetica-Oblique
+ /Encoding /WinAnsiEncoding
+ /Name /F2
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'F3': class PDFType1Font 
+5 0 obj
+% Font Helvetica-Bold
+<< /BaseFont /Helvetica-Bold
+ /Encoding /WinAnsiEncoding
+ /Name /F3
+ /Subtype /Type1
+ /Type /Font >>
+endobj
+% 'Page1': class PDFPage 
+6 0 obj
+% Page dictionary
+<< /Contents 17 0 R
+ /MediaBox [ 0
+ 0
+ 841.8898
+ 595.2756 ]
+ /Parent 16 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page2': class PDFPage 
+7 0 obj
+% Page dictionary
+<< /Contents 18 0 R
+ /MediaBox [ 0
+ 0
+ 841.8898
+ 595.2756 ]
+ /Parent 16 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page3': class PDFPage 
+8 0 obj
+% Page dictionary
+<< /Contents 19 0 R
+ /MediaBox [ 0
+ 0
+ 841.8898
+ 595.2756 ]
+ /Parent 16 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page4': class PDFPage 
+9 0 obj
+% Page dictionary
+<< /Contents 20 0 R
+ /MediaBox [ 0
+ 0
+ 841.8898
+ 595.2756 ]
+ /Parent 16 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page5': class PDFPage 
+10 0 obj
+% Page dictionary
+<< /Contents 21 0 R
+ /MediaBox [ 0
+ 0
+ 841.8898
+ 595.2756 ]
+ /Parent 16 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page6': class PDFPage 
+11 0 obj
+% Page dictionary
+<< /Contents 22 0 R
+ /MediaBox [ 0
+ 0
+ 841.8898
+ 595.2756 ]
+ /Parent 16 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page7': class PDFPage 
+12 0 obj
+% Page dictionary
+<< /Contents 23 0 R
+ /MediaBox [ 0
+ 0
+ 841.8898
+ 595.2756 ]
+ /Parent 16 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'Page8': class PDFPage 
+13 0 obj
+% Page dictionary
+<< /Contents 24 0 R
+ /MediaBox [ 0
+ 0
+ 841.8898
+ 595.2756 ]
+ /Parent 16 0 R
+ /Resources << /Font 1 0 R
+ /ProcSet [ /PDF
+ /Text
+ /ImageB
+ /ImageC
+ /ImageI ]
+ /XObject << /FormXob.437d014c666215218411a11c3a150714 3 0 R >> >>
+ /Rotate 0
+ /Trans <<  >>
+ /Type /Page >>
+endobj
+% 'R14': class PDFCatalog 
+14 0 obj
+% Document Root
+<< /Outlines 25 0 R
+ /PageMode /UseNone
+ /Pages 16 0 R
+ /Type /Catalog >>
+endobj
+% 'R15': class PDFInfo 
+15 0 obj
+<< /Author (\(anonymous\))
+ /CreationDate (D:20150103103453-03'00')
+ /Creator (\(unspecified\))
+ /Keywords ()
+ /Producer (ReportLab PDF Library - www.reportlab.com)
+ /Subject (\(unspecified\))
+ /Title (PDF Test Card II 2015-01-03 10:34:52) >>
+endobj
+% 'R16': class PDFPages 
+16 0 obj
+% page tree
+<< /Count 8
+ /Kids [ 6 0 R
+ 7 0 R
+ 8 0 R
+ 9 0 R
+ 10 0 R
+ 11 0 R
+ 12 0 R
+ 13 0 R ]
+ /Type /Pages >>
+endobj
+% 'R17': class PDFStream 
+17 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 2090 >>
+stream
+Gat=-9lJcG&A9%PJ!a_LC_W$.5,RQL]#Xs/`*M`'(Ii"Q(:*"dj^c'>IS#Em`&&+k+@2Of]Fectaet8W+QPaXr[i<o+'*@R)$.UYH3=oe0s#9OdqZGgB=U87Mc#R&S=fjp8]mfoMbn`Rc#TN<6Q(qlM,#4OA.\bn_a,9^E?SU*<`psi=.bt*pNQ3?`)3rQ;-]u4MG\t&*[=&a.O0P.0LIRBCmKuDjmQjg<.mPn'+BR4aiY0_U*Ee-AAZ<In&7.`bnI3SY[Um,hneS*XPV,UIMjTWiZLq3pl-NSZ-B]Z;R&qjf?hop4290`j>S!c7]W!g::(,3gK/Jel]/,\LZ:2P(^;:i<OLPd"7T[7.lqdVV.<<T!*3<MTWk:6@FYAggZDV?iIQKr%f;-R2uu__oSL"(fTQaZ!W4/-@oWQ/f<D$GB(`$qLP',0?fBA>Zn&UNb-hnb/HoH!CX'e'Lo^J$YJHbe4L\i3Uhu."(pRk$Sd/FWgo=INK*b/!(Opld(I8\.,";"loBqP+_=M\E$Y$smG*!t/#fRhsAd.qB0-#=*qtk=@*J()j'j7]\>`EZdIKrDoYstuqReLSh,)g(E^T7XMl_F)h)sX\B3neWR8I*R8bijLO8IO>?-]Cj?,>c8?;9o.,\s/U.M3+@*OSK#>cF>"5b>47lUo?m./+Oh-M]=?H%P<CTpV5omUik#Ieu1K54Pt=p\r3cC[M_@T'P(q'UG_Us0=%`D9u'V."C]NJ)LgS+NkuNYCRZ\PQZQsZS-2]P7eSM`*r(lfh8%0N+ttWG&B@-]2bZ]CRcg,hr5IiQF$C8+U--4g>*r\$kCNBJLL^5N,&VK=R:%h9CZPUXa]-&K-]JIX7lRNK$"(]8cg17aeUeXdYpXF,BO+A-aZutN/Jk#db_`iGk5ki#<Q$!"R[%^8mf;0C9)S7bPh?H2A4cmY9IZY/6;r-SL*2Q'q9=#uL(tHa=Hin8$NFSL*6XKmRE;\Sac6G6fhk#J*ETUb=k?@8j+/NlGh\I1omPdn6sGTH/6oZK\Cg(VB*k#]E"t%ed'8c<"a%)DJ04$I[%/V_=h]d_=Oa555%M+eBaEXkf:p2`[0A[mej.9M2)T1I3Dul8=0ZhccThJC]nW?.i\O@2eNdJEd!3mkNeZHJIW9(QL:T9-:3t1+S/`fGd\q`R$UE\JHa&D/"noUZ.er=p8%mL7cH7A-g!`4TfiNFUfiN-AP?`Ik&QHj;oqPi0$>9=Y;t)X5>>$&Pfc=9U""HXmpRP09#8M@0lupG']`uiBr.ViZT[67skc93lgKIGpGA\pGini+@l<m+43Y7$deT3d@:5s?.VLd?);cQmTD3:Ma7smI!r0c'NNrmY40EV??p4@pe]q\'.$VihfD^[O:P#G;^^,W%12>[aXHJNQo2TXPdC8AK0=NfM64&!-Y6fmi@nu1NJ/ZB%`akujR5?9d):f5+?pg3RIpub>oaTo_s"sIWkW0(tDYZ=Oa_9dF6H451erIGf>(Thp@K*R'oL,sZPNHA*mJGlf!T8PeB5<`&JFE2uGRSUg-EqYPM&Fmn@(@LN2$Vr3&4<BnbXbBiWWCp6)FdMTCC=Wfla:G'monH.)A7nL_SXj<RWKZ"\O4`,g3iUIb>=K^dc-AaE2Q`4#&kZdYR<\"m_YL<c`(O$OeVWN507@scZ1N&4-%aQ4B/^_(5!>O9L='.5(nK2C7PbKaY;b+i5PhgL4ml8%eBO#=i3s&t/UR!Iif9OtqSt[1/+%_5SsI,t(U3f0@t.]p];E9SV2&rGmpYM-H@@\h%XmMHiQK5$msSPHXXUS;!UD]iPYpH0!pR%L-kg50k&n3gjb^e&96PUOJTZ&oNZF[.9O1Zp;CbA,K.k61O.1b4a-MdUUQ^hino<.RE,Ob]be]WK\Hm9G,uuY8*.3m6M_GAXZ>pPSnY*hB7@8]\[rN)Ci(L1WKK8g:.i2V(5&B=)beY+L\Vs=Q$7hBNPY#I5P)]$'X>H+1m+@LXcG<8lAAIq4^E5lc`XiA:qT(1GqY_d;]X0Bp7&]=YS36;h`X!.=M;2RWYQ#]T;hY%--2bb:JCesB@@(,UlKh=D7UM-5c"f'4.2XTPrrY;P!0.~>endstream
+endobj
+% 'R18': class PDFStream 
+18 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1741 >>
+stream
+Gat=,gMZ%0&:HLqJ!e:CU/=<Vf>ff&?$+J3gVbLt@UEf<Z*fib=/(oTmn8NS8Vq".MZe%`3CD(3c5]\L&BZ*ErS:EQ5HWl+,6EO,o`urQ,$=dF+'-S(^WQd9=H%h7U)4%nN>(Qa>_JZEfe"#k5OA=<)=I\6l($gY.1W(+MXo&W@M?_$EV#;OeR*\E6mUTC.,#q<Jl.J((*Q'Xg(9/$0LZT/n`AbkmWYl<b/5@?0o"Jc1l;jTU^=-&0&XC'pZb6sq%G8SYUW&_hSJIrXPS/8]NU/f;%U`UoURMg(V@?\=r+`=D*bE+`4XVU1iG66>-6og:/!oM*D0A;>-RD5jlB0^Q9k&OXB,4m"o1f&7]h2(UKc:PYhHFL_3PC2PV'7hIOqt4QJWDDTqj&-!3^r:Z/u/o\mrlK:9m$K-.$rG'r,nKmn20>*E.-9<]!Kdp-:PG=/J+_R9J"JNOr)prQre4NAWgWoDl8Wa',Sn\;[b*)_OWl;6sY^P0`F>\)efi6^/r(?@La\;Drc+/o!gKQpCmqN.Xt"L`2TKTP`Z7&rs^;LX6'8C+_7s&N?1q'\rd1^l8Q4,ft-[FU0pHLf`-RFZi=1YG!!t(T`bs;ZY3ug<mfhd0AZ.Dj]=;7po<aA%21Kl`uEOAHVl;17Us&JsW)Z4@KoYV7bklOCWV@f-l9+_;kDo\j`^g3SbV7Q2lrWEkhHre2@C75s^rMdb>saAW_i31]^*T*e][BAIEu!<%th5h])Poe/L<R%#tE&-Y0m68NP]CZ5\[\QuJ")'LYfjaDK=MXnZrh5Q6oE,.X?89i)U5P2spA^np)/EIDZS0Dl#MOU3p;g<G8TQVE+Fp@;mIpM<q#g<6'Rs39l/U`EkJlJ]58aP\X?G>d!aIScI@\%J^J+kS'fZG(D)%.Q)_OFCdMcmBlZm=Q*E0iaZ*8]L:d8u8&PeBqgB^E2]M;]Ok>D/t3!.d_;KL_+8E+tjN4kpO=JFj#$92e^Y`1\,QcB[;U):ICqh&Y446bM4;TR9STSEO#;,RUY6JBuR'\5qL`b3Ih_o2E:6t@$#gY%.L`K8R'^N>'4ar1kTpn?1dgTSt:3*opqVmb]dJ:8!TKSXLmsn*_?iJif\O-EKO,Me4X%';dCtoFo`Jn&j4i,ITd0ZJI/$rVd;-ca*@`j&^efq!1kX6(-"YcH4l1_jo'36i(5YF3DW!B+etC72eOsG0.jDD&oY'hL:Fg"/U59&_IC86q80N$c(=O+1K^AX`>"Vk4qdFSb%Yhd:)1<>=n]opin4%7gu.93lMBH1EI;GtZe;6[*shFKT?bqZK:CWgku],mfk^5V<2U<>CV:kI"(XMmiSq<Q>Wh=KBN'';VkTH!7-.VggW3Gtg(aPLV/cLad#,],U86PWoUBXtU.'i^&!1>!oGQF8'd3<VBH^DTs!]E>$fo0%;%!NsT+pH0'[`Cb!F+YacT:O\KE[_-`kd-kf%fk,$Q^*<dcWbNc;_Ne#bO+/Z3+s^Knm.lG:.`DWU0A/i`0N26)3?%eTD;+[k[15UZsK4e?HRFR(>3>mW,PXgM8%]a<l\U%4*6g*',%]Z_:)&HWq8GCt[bG#UQ6Je?HDNUKH$M\)C18C=q:XE@f#>VgK1N5):I)"d0ATLdtmlK.+eh#Vq?I*.j)6(7m-j'o*a,WucTo((somh&Vk'$igFl\ot\90KU*OU+G_i<S?d>"*9'u/kfi#!s^eeM<Ti'_-H^5Dt'$E?1o/O"ugb1>l5+(O@br~>endstream
+endobj
+% 'R19': class PDFStream 
+19 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1580 >>
+stream
+Gat=m9lo&I&4#]Qd=9fDRqW`?"SctQVb(M^^,4B6=%7cnALLEPkd^Wd"[EDfaHh%8M8u4<5*5XI@7,VZK_m.7n+@a[[hX;g/3taf4b2%ML=JG7=tLQj/f/P;Q-9T^7V8YWKc@F)LlgjCQ](H[&]Uk17Mh0L@?CAf<1+M*f-+.oWJ]fsj6*T&s3lD@FC&j<eE`hWPVc!5>09=WFl#Y68u^eDDRoNmr6.nZCQSp7'\)YH8VJolkHNZqJnqI^mT4)6n$[XqeS]'f:U'["Wt.MVeX>u+B>OrQK4k%dHe]+X[(FA2h8!Fu)gH"r,k#P!3SU5Hi5H21gE0Y3[the;hE@F!.H324]OeM)mS;\h)J=.1?u)6km5%j]mE*5b%aD.>_.hXe[2\o+51uKeD=ca>5^*5*h=`L@C`]]#i"!&<C0P?])q`p-YWFtUp2gXCl?n96d+`!BKkB.b5..fVe9681\3#2IT>NBgnc7!aF+gFZSdtaY6g*_sflcJPG'C1DPtU\Gs7L6>aGc4'+lW"\QToj-SsP@f^G)C64W'qLiR`kr>PNQhM0VRdT8P]jK<?4F:JuI#RTh3#$4&nUAn1G,)S\prLf#F(I2g&'c\ilL:_-hjf\Tp6Aq9'8T@)]H2EeQhS1ll:%q$>8O(%J6rEb4NN:H;Ue=iJ8;Pe/"E;A+P(G8Wl5Zq/k;:QEZ+tMk/4FDD(\+4UtMg]C'k2b@(F*;d%AmX=&Oh&PTj[Pla:Rg/?p[SZo$BsRDeJGa,JnlMb=m4iHc`c7R2jk52^;0CV]I<'HElDDDQ`@Cl*3NPB,('RN]fIBY\*BS:H"gq-Y7&V77A3ks+q,6-D+O+-iH`m'HIFEkdk#f$=NFK6HB/?XRqC';B$m)[d@7t`[TSgN,Js&L=nJRooVPd`B!@qC8U4);bF?=;D[%/o)/Ss-Yb4UoY>#;KRqC';B$m)[d@7t(11Xa]&=ti*U,U>k2pJ'UK*@O(I;M;qhDC/I1lL3IMr"lnh-?(jD*iL(1lL3IMr$:Kh@(0aT_k1fTs)ipHIFEkdk#f$=SHVsp9b38Gr++:c![;*K8n_-(1]`)[0bf;dk#go/:,brH8AZbRd=f'_XjX-oVPd`VHNP'YjQLblt[9Oo;5[_VHNPg=nH=1+=5^m-A:PVZfk,ikY8DIc!^L)*2-[0],HYuBc;uV1`DVs.$S70/,B.&7\_\t7Um?r`XEOifua`<PL4&#VU9'NUX>H[6;BaehXJa7_^"=R:Rj@+E,tBikhEB^m`KFW.D+Q1m"S_"7d$N?chK<?T4%Zrnu)4V1>,A<@>s)*QfkLB]_#FkEOXMS@70nF*cK\U=6It?5'FBFIdO'W=!XPgLcMT#S-q'LFHU_(Ch(1ME\<;2<@,'J&9DD\M[qOTP$36h\NHk1LR=8s/O#+R=XUWP&9CiLM[qOD,dmCYF#p;>LR;"3/O%+C88FX.kbs\Cl<,EE;FigK_^&f\q<Xo@1TqrR+]]_N*Z&1.T5kG>H\Dc&VB4?Z#@]@hnlh)I/\H!^#;a/oH<an;S^'6_!C`-3$d/W,Lqm51WD5nJRHaLXC%fqjft91SHjp2$`W)F4IC0~>endstream
+endobj
+% 'R20': class PDFStream 
+20 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1360 >>
+stream
+Gat=l9lK&M&;KWXr#b'g/m9jA,op33;kV4.>63KZem`)?ABC+$:%RgH;Dq*,EJ@W7YVDT%jLdip6BVC)J(/o8%KO7DnF;eGAPh1b'q'U;%R*nIc+i!B4gBrX$A>2mbG?tr[N"3gj26%]DGOMap.B*(S@_8Q=jAcgKIEBAB;[/dRub%rGkbqHRL,QEKSl<uMG_K/+XjHAh=6q+P#DCr&)5?9mLp$q99Kl6)3fTG<J8k[k"m('^h&>rk#^c$n%*k#Wgu6M'3*k^qVYns(l@E",Edj)*9hPAYb.WWg4run0^Jc$[*]5L2B#eZedjQ!lP\EoZ-rs6canCC3&=LS0N>c`WnOoqQqqQ59f)-Yh<6SGC9JuoNLoIERpaq\O'Mipc'*<3G4i15^sI`5Y/b07edpIm0V(%]>mGN0^d6S#gHTe+RTu`84\YIGkM73Eh)JNg?A"BkNdfu*Ci;PM5)ch'Vm/EP4V!Od*H<,oS<Me=`p28aB3/"%Vu?J#h.2\q;Gjt%rVVHD_:*SVgVf0T%Nm(@Lj_dpftlR(O2N*FISO?/K!+dc="`of1G?oA"usD&;-U2\AM#pZ>Fp)E)VeQCeW7C?pVS]NdH&'6iMj4@H9CJ="Cj%tAu=Q/FD^0fc2F-tdR?K\W;^<2b=t9Sb?l3[9bY]EGq"YF'kIE\ciQZGpE*_k/UjjL^2?Bn'JSd;qot[j_i#)K8L=enqFl?Qg)9>B'q?_@EQ6-/S6`r7+W49H?/YVf0"K13;;qWn=)b"YX>%Iti0R?:Ih#PC`,jQ.90G1HRSIZV5&)oE3#`K`ZQVCi)cDm8RakPEkY9k@P,912K5R1g\oBXl:1/VbMX"N01u1,1FQ72aNO(op!c&,Ta)mr8,i&d.f:B^'h$L17S\bG.'%OZ<BtA:Bkf2;K)eXfk"P.CHF&]V>YA4G\d#G@t2pMW`$*:-#BO*\CBtA:Bkf2;K)eXfk";WCSle2ZU\ZNIM(J`Ee>65asj(o9u^tL"BU:X)PCH1TJj/CRgUL%sB$9;;;o(7NgUL#[8HGql/'doXsd97mG9,Wb9`Am,tj/?%LJ-&6A(f)eo39h7=W)nqQ??$$]G&R/)oGu]6GO.fVYo.u1?8Q)Nd4%h_iUdFOTAT;*I?e'n7k@/4Hi$(SQOiecIgG4CCUtbh[8XBC\mSWUeAoPNB?];/C?77KpX-:&IF\h@Juj>gFBq5`.Mce(T30'Ac/<*4=KEBfA0"<jeP`P:.AKH)<?QQ$LKoNVUF>me#Th$j%`(Y#R916.]?rVXp1E=f0Ng#DecO]a!+(OoWOa%@ZOm5$Q-0MW[n:9X!gM]f_R+hP4Rh'.bZAM:qDqu.7?9S)G+/bqY,YmAq&^nAlE1~>endstream
+endobj
+% 'R21': class PDFStream 
+21 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1777 >>
+stream
+Gat=mgMZ%0&;KW_p`8KP?$$hOT[W"?[Tg+PJMn*thC:EnCEZ?R/18]sQ_[#I9K]2`fHA:\^*2Y]Ei=de+I<%`rk:AmHnOCO.fhu1Hih/0%cqWu;n665ZX/cNV'JZa-R>EhP00`r.b:2?[pGKt=NAkud4$cHKB-Y_NHiZmTj8P,Z<4;J^NTS7n*Vpi/DJ0tDpgJ=,bZLHKN*V@=@JB4,94F>ld_X(CGl>Fi[CZ1Ku2-rAOrn9#3A,u>e#0"5!dX\MrkbsH>(5-:k"&fK9l%F-C40M:1F3n1YpZpr;]hrmoluM62WeqRk6#2Au"4!D)]82(na&4)fZGV+LY@LP:IB8L*W*bQ2CC\nuIq2:'9iO[2")mj^+G[CrK6$bm@/BmbDX;;1;E8N_T0r$dc:(SjiYda(cu$J/i*HDAoJ-/K@1/f'TUPVj"9J)<!FE@bC%@g@UqVm0-$pF`/)a7ZI,:*^_tmGj27R<./t.eVljCo/qk(-`s7`7>-od=7tt8H5._\.8g4cJ):4,I.4FJ[Akp#%L5N;)TA^HPhEjik_nVqf`+(*UGE/pMg6pe8!AofG(9du22c$[540^k=N_?GG(]4/Q@<1.4a#R'H<L8_J<sHAkj^($*i(eKQs>Lr&=$Kj^%PP%V9U>XeFA_:3hIguR66Shm8'"=/lRm!<od,H(HHjg3V3BE5.itdQoXp-\M_h_`QP]Rl>D(@g1H'n&nPc0UCDJr2qcQm+ukF;.-;."pqoo;!cHtX^3d$;NPMEb8]6dVq:!"!^b<+^L3bWuJ\3*;k>'*(XeX&,V3O:EP3X<-O2Rn@O!mX/)a*(7nDX:imN:?)c(6+M2,h1iDHIgYk!XY,eo:b6*J;>#i2&:eA"OjPf-=Os`fNh!0V46gZ_7/O%'-#9`OfdBQPNuGn%-EqgkN;[KEl[c9ICbeOTu7KOl8W#i8R'sr6dojpf6iD,1#"Q'O1bE:LmSs">1HPnOj%Hpf5-i!jidT$m(0,)_rhoJ;Y?%^^J[2>b-bMI=2N@FMjU>Yj<n<BE4K\`s='/@UojB4TjQ!?/;p)C.r^uqS"#^^9/CLF<:/H[fLhPg!XEpJS(s6,=%I_8Dl>'4^!$l)0"ic2uM+;0]H.;is8I>*\<fb"g`nqRfS"'\+QU^b#\gieXYhPk&Vi8]F.;C_:.cY,6'P?Nu$#nP0(Sic%(`(R/F/:c/9!0r0d&tia[T8S8&aXHLXk66klo+:r4Zt&c'Fs[BW_`,?DpO;2c,-0hQE%._1-28[88:8l3GT_+1b&:rFhL$)[nrJ8hUWS.ZNU9(5]Z&eqTC:r4Zt&c"nHooN+(,#/G.MH,6P<XDAX,rbsZ"?RYpS.^2`Wrtkm&sR?-E(!u>"b`P%eU`ciA>"TQJHAjT:-]S2Fd0*Kn1fk+PV="P^hUXk8:jQr&lo)uL=(Ma7KX!"%6+A>f\S%8hJ%SdN=tru-2cJ;j]NXRP_Ymli<OYt3?EX.j#nE!l!R!d)`lKp_05MPn"qtnW4H%Vk$"$]l<;`pj=+#7<atfQqGNWJk]e.1]6M:ae\9Ok;Ps&*lM77?I$AtAC!J>J;pQgcl_D"WM_^hVo5[^*o-I]qb&fi0je>H3,@3"FZp%B4\L>r&E\A5?3a_16U.jb1?7sBB53h7(9]q?4>iqC2KpPCdb9ZZla_#fD?5gq5Fo94HkMW7G1Q]:([ZekO)X>W$gr@BNCaXWKDi>RL827Q:^5Fqi%,cE*gI_4cmk]/[kh&VPD[d(ZlD2:`=j1uJrt.!_B\##,@`Ae%=Kh]+E6mo6~>endstream
+endobj
+% 'R22': class PDFStream 
+22 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1391 >>
+stream
+Gat=l968iG&BF7.d<F6<RqZS!8<>s28^hCOLF2/*Eht'a@YQ(,P-V-,?N;if[TCO\XHC0Nh_+V`QN0l*lAqD.blQbS#&ZY&TF@7oTQuhjo,%>UXB5G)=7hnl1_Yre1h1)?<7H4_N+^kH=#QY;GkOV6!7"<#H<.=&-[B#;=37&7=KcU,NRQkPGb=*1g_-&oKFj(XN)hs8/YsECdXm]?LQCJAp"@!0->6+/_?pLTCFQ9F3meq9K.4>(p"m?:IXICY)4GI-j\O6NKBA_enZ!mAjr#U=rdueNl#uq-g:l;NEXRg'Du%,u.f+RqZ)G'=>i7.LkRPX>*osQHmFC@K80s^u`ET@2I5ce)[7\iZ^g=HR3G$S(jXagjQaZ3mR.oX?hnm'Qd`ohH4f]&0#EY!e3lA5Y8KFIeCeoHimBD:sCklo\ol?Wu:Y?0J1<F+6LNYJ5g9m9?Uihk?\/V"+B9P\C#C)]k,IGpE)K^n\W9To7AlMgg%5L;^jA5aJD8"(!6>JmGjl_uf[1Ak[X$Lq<WSdbF_(qb:Lc0Ui]D+q\+n9UdU&fr/ifT/2ChfYK<e(4@'uY,i?07:nSE5Q.Zb`_h/q.V&4cJDF-e87a!`,@.dGn*4'.EH-?tq)25dkDIc.HBoQ_kC!"oD(rYu5F0nFBMEVn7eNC3uq\9N6-<^X*<7#nQK2m9AB6HZ%^JZjC,oRI3"`7*?oB36b&mWG"qR:m5^`c3R0:SWR0ZAW,Ftm3:L)rgq-MDV.L])-1:\&3OjmX9(V0C,L+&"UWCgRcV'rnt@j:c1j,oO+5ZhW4kc2"g'Q"7I>]!E><_B\j&p`0B.S%&Yq@2WUjB^7MPAuLM(V?KHdQ`:r99Q&N(ZrU_4C39(4B,$&U\g.,gHL#V\T/8l3GV_6Z*I.,pJaKNEaMC4"kf,rjnK>fgH?i.tBb'2HXa"K3`38l3GV_6Z*I.,pJaKNEaMl8Y2:nMoNni)uQ_'QH`A_CNG7[A>0N4H=Y4GS[1[7@Y!Tn4IX&-r$jh*:ZYj/5?M/3$g!3Q/IH^JL?,DK[YM8YVK%lW^$S4![jX7/p3Ct)Xn_I"%lZ).,Zr?";JsHNY5(hT#5;.$*+(1S-GJ`Sm:,#iABIQX9Oon)Gn4`^^9ZsT0AL8cQqa"8b,945*4^_O;s#9-mT$@2$V/G#_D3>Ge%,DM]oM&6@B/%poB3/c#!j#^mJ=P91:4V4HFm4oKF`KT/)suelCq_VY=(9nl<M#QAVUVD0fP1eY5e,@o4i3oKEo>'&J6+W0B?AUl5X0K0"mgN$>3P7n)pOL:@@fJXT5ul)<oeL;%c`lT!jil"Ftped)7NlcXB,QZ6dD5[G1;3blG.5B%"Q0!eFPS`,+.AmuX#>*-r,&eR6Hf_(U3$[tHnp$.%*F"n(~>endstream
+endobj
+% 'R23': class PDFStream 
+23 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1584 >>
+stream
+Gat=m;/b2I&:iXIpcmPD<bs6WM3RYB@I8T=0C+R+YH#jc.V-_dQ"Kjd,:T*03k:bW,Y2mgO4&HPO,=e]_L9PqF*do^D$05k8rsB<pE5BqJB]J:YZ\1/?*E=C<AH@,BUPht)`MNF&g9%nXB4$D,)fU,N&Hd\@?>i<<*:B%U(4/#?)h#1hLFmI_a"+OXN8SUON#cfUSLqr.\pmVguaUGU6GiZhQL"1L%!\HA1]R1[":?q.B--5ko;U::iMEehYddes4qkEY\D/'rWJ^/Y^%$A?JHt_MbIe]r8=,0[h&?JR]_&ug)Z.G^N%r_._4n`._4<=+5tn5clPrQ4kSe.GAl?`XV>gqWF*!cm+X>+n&?698(cR.B86mRH[E3*ZX_I-B/oAWa)2,hh(.mge2>Qi!r=.omrir1;tFDq!-aR]A(O"fgqgfba7f;Tg%.5JeFa13ENnJH&']:]I;3]:WO5)u\3#2JT>NNknd&#YF+S#f+-6D]A+/\FgMQDRY!(KtR$']4O)O>aVM2+2K\PCVs6r$n>-Es8@RLA)crt"tpP9>Apj:/?Gt+U5M`EhNW,(Kd.Z[YPNA>WA!+Ic(S""/=0*NOhOa-D6#[O'l+)@hP^)ub#k._emWV%cf3n\*F(JYA#QJrs%j45rdrL<9!:l3bPqpBPb-`^522C,g2mE5md<#[7O.Pk(1_(W*G_8?/_(].6^h=opC203j0Y3hb8h'Y?=Dhc><A4>TL?c`hjG(`YS^m3;MY#Kh%.fqAWaJ:9/%A"6Cc?1Ie.;nX,^l>>"aq]DYhl=sC%`BW\n.p7iFsc9f1H\iaC3UNWKkGC'GSXq&!=O1H=mlZ"k0:6rc*QWYZfo)QKj9nEpOk*hk#q?==nLiZoNo>ED6mif-Y/W(c_<AEU,UDmpAu+04`(^:gb/#<C2PE3i_/EA!?:30!?:30!?:30#n*bDpUCU:baW7mRqL-<B@2&,$VIaPg]^jCc*QWYZfoZ?ke2KMQ*Yhm"^1!4ZfoZ?kfpHt]mt6TBX)p>"^1!4ZfoZ?kfpHt]mp84,jS/KW(S=J8KoQQ,3VE>mSA=UX.k`T66f?]7\U6L7$T\BOG;S>BEV=+"B@tq<Cd6mBEVk^DC@>n.O9Tq,_@KkJgrV:4pJ6<"HB&]M4b34TF-OK$B9S#CtmDEWfRLdO9hkJ#cc7-5E92H80WqQ7._UYW'M'DJgR.$qjf","A(ufP)'_r&LD)l1u%7?&LBsl8ruH*+GhL4'9MgXFk@HW$2e&G2E4:dB,J4n(&q+nTBZ7uSU[C*%s5Cfq83qj*S=q2=+OY13KTc&MLbQ0;L(DTbtEOc)GfOD(_.[f1VIbSWii,9I-g2RQ+C_OR:MNm0it;!k<dCl,0@B7FqAGPS-rh%<Cnc+`*A_[i^:rSU_Y%]/l-6P+m*<5M[s;mek%GW`*ASWi^:qXU_Y%]Y"3<t+m)a%M[qNidTYc<gN?Cd4fbAP$7TV1kbJVM?_):Yju&q\`!W:iVLAm8kL[MA,@:GIl`$L=&;(j^f>Z68iI(SBbQ+d1WLq$Fr\^&D`oL&_Gp!;'Gcd=t<4&6b:B+Xf]ejMof>^M)m]^$r%hR^Q'`~>endstream
+endobj
+% 'R24': class PDFStream 
+24 0 obj
+% page stream
+<< /Filter [ /ASCII85Decode
+ /FlateDecode ]
+ /Length 1325 >>
+stream
+Gat=l997gc&:j3NoH35*%9eI(8]Ls.$5@i$W^EtIc*\;-Ot17Qh1&dp>*G1p`sdPWeel_'EBZQsd1hE4U[J0M"Rr[IpR`m2#0d6H;$^k'iDYqQs5k2I@2UX2#Y>D)8nD2f)0))/OCspR`3j5rZrXuQCLfUZ=WrS4[7ceOV2@B^s*:,0s,::m_95!8@],H"<&.V`8m=o3]VUdU<5@s4T)IbW;&?Sd"_!Q[m<dPd8A-j8k2ZlP6bR[cTHCr7rY_/Bl1H^VI"URPds0CV01A/P&O4stQgSftT^BA/T_G\Ss-=bmXeJ&2)r(!CN!hc6"hN0nf-`^4H@N7_1K0-JW-ldg3Hd3G=)3cW"cg1Ml`#EsW+QQd]sM'0_gEFGq`T<aT60\8DkG8SN!&;4H?t<eHdK3P\]FcTn"CcqE74.#%>S99ZQ#me($9)UbO,Z'DAmBWW55ETPFo?HHaR5:2,&%@Vl;gH4,o;Rm;X"<S[714-L/3/(W_^9C&`V)ZU,:..gjns?iI8iGfmA/%Lf>p"B)OWfKE]]*r]Je,gMM=k9NMA#eLl0Uq"1.fdQ.rE.F"D[Tlhu>&o:W4Rm/D\6[G2cY]V9EEr-H`kPg;WO"C,53m@n'<W!\VW%VuCZa$hrQTKL.\Tjas!]EuRMulE^YA>G0X9']?L"Oe<F*FZ[":le_n0"E/Uk8!q>44RVLV7Ih!aZB>[E([:'sjdeedo+^0BNe+uiN,i/H2f3(%XN83rM;=#`]ha^mbo&m)S.E2Dio1<!VZf;d5b"#<E[[*<NL%Z5oO6'3i.-kaa$,hV+4=_DkT"\""MM?FY.#q@>9<,_sWTh,t5#q@>9<)=j=TL_nq&[V"Q8d._t$BB?G*:YL<i`0k=5a>$CTL_mFOe@:M5m9]/$BCKD`T4JJOe@:M5m9]/$Ans$*&0C\jL3*kTRn@R"\""MM?FY6!D8R1*_1ehM?FY.#q@>9<,fc>?meWE_Mb(?pHT%gJJ-f@-_O0$GEhS0.,cIK_FpPTQbWohadnG)?32Fc"A3nFPjf;F!Bdp5;8Pu!KU4q107aaB![l2NIerjcrHOKS3_;Q+Un:BNR7L(@EZUCmOIV$c,fIL\4LcFUm-0R;%Y+2JFUI:@)nI7/G"QaE8![n\b]0o0R5!^#g>krkF0r+0S..ig,+DgP*ET5oe7-=W':W0A(ijFkM[`%6Chnlg](Mqb3i]"2'N.DCaA!O-We,/Hi,K4\&pskIM01tm'D3ZU-d*<Vaa.6R(@XTmn62pZd@Id#5m0_ZYNsT,l7YF+.)jg2BE93"i2sChDMBaSf&[-lkTc/EDA-I+:Bchmrr[i0,7F~>endstream
+endobj
+% 'R25': class PDFOutlines 
+25 0 obj
+<< /Count 0
+ /Type /Outlines >>
+endobj
+xref
+0 26
+0000000000 65535 f
+0000000113 00000 n
+0000000233 00000 n
+0000000439 00000 n
+0000004074 00000 n
+0000004255 00000 n
+0000004428 00000 n
+0000004772 00000 n
+0000005116 00000 n
+0000005460 00000 n
+0000005804 00000 n
+0000006149 00000 n
+0000006494 00000 n
+0000006839 00000 n
+0000007185 00000 n
+0000007323 00000 n
+0000007617 00000 n
+0000007784 00000 n
+0000010017 00000 n
+0000011901 00000 n
+0000013624 00000 n
+0000015127 00000 n
+0000017047 00000 n
+0000018581 00000 n
+0000020308 00000 n
+0000021778 00000 n
+trailer
+<< /ID 
+ % ReportLab generated PDF document -- digest (http://www.reportlab.com) 
+ [(\005\034S\267\270\010!\310\226\245\)\022|\037l\207) (\005\034S\267\270\010!\310\226\245\)\022|\037l\207)] 
+
+ /Info 15 0 R
+ /Root 14 0 R
+ /Size 26 >>
+startxref
+21830
+%%EOF


### PR DESCRIPTION
I plan to re-factor the pdf codec so that styling will be easier. To ensure that the change can be properly tested I have added this test along with two sample files from the test. Currently the test will consist of manually verifying the file created matched the file on the repository. Later an automatic diff could be added for this test.