### PR TITLE
[Fix]: Representation of item name in autocomplete widget

### DIFF
--- a/modules/s3/s3widgets.py
+++ b/modules/s3/s3widgets.py
@@ -7440,9 +7440,9 @@ def search_ac(r, **attr):
         output = []
         append = output.append
         for row in rows:
-            record = dict(id = row.id,
-                          label = row[fieldname],
-                          )
+            record = {"id": row.id,
+                      fieldname: row[fieldname],
+                      }
             append(record)
 
     current.response.headers["Content-Type"] = "application/json"


### PR DESCRIPTION
http://127.0.0.1:8000/eden/req/req/1/req_item --> Add Item to request , Autocomplete for Item field not working before. (Giving link of localhost because demo is not working ;) )