### PR TITLE
DRMP one line bug fix and NYC menu nav bar css fix

### DIFF
--- a/modules/templates/DRMP/config.py
+++ b/modules/templates/DRMP/config.py
@@ -14,7 +14,7 @@ from gluon.html import *
 from gluon.storage import Storage
 from gluon.validators import IS_EMPTY_OR, IS_NOT_EMPTY
 
-from s3import FS, IS_ONE_OF, S3DateTime, S3Represent, s3_auth_user_represent_name, s3_avatar_represent, s3_unicode
+from s3 import FS, IS_ONE_OF, S3DateTime, S3Represent, s3_auth_user_represent_name, s3_avatar_represent, s3_unicode
 
 datetime_represent = lambda dt: S3DateTime.datetime_represent(dt, utc=True)
 

--- a/static/themes/NYC/menu.css
+++ b/static/themes/NYC/menu.css
@@ -14,13 +14,18 @@
 }
 .navbar .nav > li > a  {
     padding: 12px;
-    font-size: 18px;
-    height: 22px;
+    font-family: 'Open Sans','Lucida Grande','Lucida Sans',sans-serif;
+    font-size: 13px;
+    font-style: normal;
+    font-weight: normal;
+    letter-spacing: 0;
+    text-transform: capitalize;
+
 }
 
 .navbar .nav.pull-right > li > a {
     font-family: 'Open Sans','Lucida Grande','Lucida Sans',sans-serif;
-    font-size: 13px;
+    font-size: 14px;
     font-style: normal;
     font-weight: normal;
     letter-spacing: 0;


### PR DESCRIPTION
The CSS fix for NYC template.
Browser : Google Chrome (Zoom level set to default)
OS : Windows 7
Screenshot:
Before the fix:
![nyc](https://cloud.githubusercontent.com/assets/6136117/5660573/c99a32cc-9747-11e4-8acc-3d2c6e1715ed.png)

After the fix:
![nyc_after](https://cloud.githubusercontent.com/assets/6136117/5660585/e4dfc754-9747-11e4-87c3-b51395e069ec.png)
