### PR TITLE
Repeatability

### DIFF
--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -631,6 +631,12 @@ class S3Config(Storage):
 
         return self.base.get("allow_testing", True)
 
+    def get_base_allow_repeatability(self):
+        """
+            Allow tests to be repeatable
+        """
+        return self.base.get("allow_repeatability", False)
+
     def get_base_migrate(self):
         """ Whether to allow Web2Py to migrate the SQL database to the new structure """
         return self.base.get("migrate", True)

--- a/modules/templates/000_config.py
+++ b/modules/templates/000_config.py
@@ -65,6 +65,8 @@ settings.base.migrate = True
 # ?debug=1
 settings.base.debug = False
 
+# Uncomment this to make the tests repeatable.
+#settings.base.allow_repeatability = True
 # Uncomment this to prevent automated test runs from remote
 # settings.base.allow_testing = False
 

--- a/tests/execution/libs/edentest_robot.py
+++ b/tests/execution/libs/edentest_robot.py
@@ -91,7 +91,7 @@ class edentest_robot(object):
             if db_type == "sqlite":
                 # Create a copy of the database.
                 call(['cp', 'applications/eden/databases/storage.db',
-                    'applications/eden/databases/storage_temp.db'])
+                      'applications/eden/databases/storage_temp.db'])
 
             elif db_type == "postgres":
                 # Get the version of postgres
@@ -99,18 +99,21 @@ class edentest_robot(object):
                 # Query to terminate the connection with database.
                 if (pg_version >= 9.2):
                     query = "SELECT pg_terminate_backend(pg_stat_activity.pid) \
-                              FROM pg_stat_activity WHERE pg_stat_activity.datname = 'sahana' \
+                              FROM pg_stat_activity \
+                              WHERE pg_stat_activity.datname = 'sahana' \
                               AND pid <> pg_backend_pid();"
                 else:
                     query = "SELECT pg_terminate_backend(pg_stat_activity.procpid) \
-                              FROM pg_stat_activity WHERE pg_stat_activity.datname = 'sahana' \
+                              FROM pg_stat_activity \
+                              WHERE pg_stat_activity.datname = 'sahana' \
                               AND procpid <> pg_backend_pid();"
 
                 # Terminate the connection.
-                call(['psql', '-q', '-c', query,'-U','postgres'])
+                call(['psql', '-q', '-c', query, '-U', 'postgres'])
 
                 # Creates a copy of the database.
-                call(['createdb', '-U', 'postgres', '-T', 'sahana', 'sahana_temp'])
+                call(['createdb', '-U', 'postgres',
+                      '-T', 'sahana', 'sahana_temp'])
 
     def switch_to_original_database(self, db_type, is_repeatable):
         """
@@ -124,25 +127,28 @@ class edentest_robot(object):
                 # Removes the modified database.
                 call(['rm', 'applications/eden/databases/storage.db'])
                 # Restore the original database.
-                call(['mv','applications/eden/databases/storage_temp.db',
-                    'applications/eden/databases/storage.db'])
+                call(['mv', 'applications/eden/databases/storage_temp.db',
+                      'applications/eden/databases/storage.db'])
 
             elif db_type == "postgres":
                 pg_version = subprocess.check_output(['psql', '-V', '-q']).split()[2]
 
                 if (pg_version >= 9.2):
                     query = "SELECT pg_terminate_backend(pg_stat_activity.pid) \
-                              FROM pg_stat_activity WHERE pg_stat_activity.datname = 'sahana' \
+                              FROM pg_stat_activity \
+                              WHERE pg_stat_activity.datname = 'sahana' \
                               AND pid <> pg_backend_pid();"
                 else:
                     query = "SELECT pg_terminate_backend(pg_stat_activity.procpid) \
-                              FROM pg_stat_activity WHERE pg_stat_activity.datname = 'sahana' \
+                              FROM pg_stat_activity \
+                              WHERE pg_stat_activity.datname = 'sahana' \
                               AND procpid <> pg_backend_pid();"
                 # Terminate the connection.
-                call(['psql', '-q', '-c', query,'-U','postgres'])
+                call(['psql', '-q', '-c', query, '-U', 'postgres'])
                 # Drops the modified database.
                 call(['dropdb', 'sahana', '-U', 'postgres'])
                 # Restores the original database.
-                call(['createdb', '-U', 'postgres', '-T', 'sahana_temp', 'sahana'])
+                call(['createdb', '-U', 'postgres',
+                      '-T', 'sahana_temp', 'sahana'])
                 # Drops the database copy.
                 call(['dropdb', 'sahana_temp', '-U', 'postgres'])

--- a/tests/execution/libs/edentest_robot.py
+++ b/tests/execution/libs/edentest_robot.py
@@ -103,16 +103,15 @@ class edentest_robot(object):
 
             elif db_type == "postgres":
 
-                db_username = re.sub('/', '', db[1])
+                db_username = re.sub("/", "", db[1])
                 db_host = db[2].split("@")[1]
                 db_port = db[3].split("/")[0]
                 db_name = db[3].split("/")[1]
 
                 # Get the version of postgres
-                temp1 = subprocess.check_output(["psql", "-V",
-                                                "-q"]).split()[2].split(".")[0]
-                temp2 = subprocess.check_output(["psql", "-V",
-                                                "-q"]).split()[2].split(".")[1]
+                version_command = subprocess.check_output(["psql", "-V", "-q"])
+                temp1 = version_command.split()[2].split(".")[0]
+                temp2 = version_command.split()[2].split(".")[1]
                 pg_version = float(("%s%s%s") % (temp1, ".", temp2))
 
                 # Query to terminate the connection with database.
@@ -129,16 +128,16 @@ class edentest_robot(object):
                                   ) % (process, db_name, process)
 
                 # Terminate the connection.
-                subprocess.call(['psql', '-h', db_host, '-p', db_port,
-                                 '-c', killconn_query, '-U', db_username])
+                subprocess.call(["psql", "-h", db_host, "-p", db_port,
+                                 "-c", killconn_query, "-U", db_username])
 
                 temp_db = "sahana_temp"
                 copydb_query = ("CREATE DATABASE %s \
                                  TEMPLATE %s;") % (temp_db, db_name)
 
                 # Creates a copy of the database.
-                subprocess.call(['psql', '-h', db_host, '-p', db_port,
-                                 '-c', copydb_query, '-U', db_username])
+                subprocess.call(["psql", "-h", db_host, "-p", db_port,
+                                 "-c", copydb_query, "-U", db_username])
 
     def switch_to_original_database(self, db_info, is_repeatable):
         """
@@ -158,28 +157,27 @@ class edentest_robot(object):
                 # Removes the modified database.
                 db_path = os.path.join("applications", "eden",
                                        "databases", "storage.db")
-                subprocess.call(['rm', db_path])
+                subprocess.call(["rm", db_path])
 
                 # Restore the original database.
                 tempdb_path = os.path.join("applications", "eden",
                                            "databases", "storage_temp.db")
                 orgndb_path = os.path.join("applications", "eden",
                                            "databases", "storage.db")
-                subprocess.call(['mv', tempdb_path, orgndb_path])
+                subprocess.call(["mv", tempdb_path, orgndb_path])
 
             elif db_type == "postgres":
 
-                db_username = re.sub('/', '', db[1])
+                db_username = re.sub("/", "", db[1])
                 db_host = db[2].split("@")[1]
                 db_port = db[3].split("/")[0]
                 db_name = db[3].split("/")[1]
 
                 # Get the version of postgres
-                temp1 = subprocess.check_output(["psql", "-V",
-                                                "-q"]).split()[2].split(".")[0]
-                temp2 = subprocess.check_output(["psql", "-V",
-                                                "-q"]).split()[2].split(".")[1]
-                pg_version = float(temp1 + "." + temp2)
+                version_command = subprocess.check_output(["psql", "-V", "-q"])
+                temp1 = version_command.split()[2].split(".")[0]
+                temp2 = version_command.split()[2].split(".")[1]
+                pg_version = float(("%s%s%s") % (temp1, ".", temp2))
 
                 # Query to terminate the connection with database.
                 if (pg_version >= 9.2):
@@ -195,22 +193,22 @@ class edentest_robot(object):
                                   ) % (process, db_name, process)
 
                 # Terminate the connection.
-                subprocess.call(['psql', '-h', db_host, '-p', db_port,
-                                 '-c', killconn_query, '-U', db_username])
+                subprocess.call(["psq", "-h", db_host, "-p", db_port,
+                                 "-c", killconn_query, "-U", db_username])
 
                 # Drops the modified database.
                 dropdb_query = ("DROP DATABASE %s;") % db_name
-                subprocess.call(['psql', '-h', db_host, '-p', db_port,
-                                 '-c', dropdb_query, '-U', db_username])
+                subprocess.call(["psql", "-h", db_host, "-p", db_port,
+                                 "-c", dropdb_query, "-U", db_username])
 
                 # Restores the original database.
                 temp_db = "sahana_temp"
                 createdb_query = ("CREATE DATABASE %s \
                                    TEMPLATE %s;") % (db_name, temp_db)
-                subprocess.call(['psql', '-h', db_host, '-p', db_port,
-                                 '-c', createdb_query, '-U', db_username])
+                subprocess.call(["psql", "-h", db_host, "-p", db_port,
+                                 "-c", createdb_query, "-U", db_username])
 
                 # Drops the database copy.
                 dropdb_final = ("DROP DATABASE %s;") % temp_db
-                subprocess.call(['psql', '-h', db_host, '-p', db_port,
-                                 '-c', dropdb_final, '-U', db_username])
+                subprocess.call(["psql", "-h", db_host, "-p", db_port,
+                                 "-c", dropdb_final, "-U", db_username])

--- a/tests/implementation/resources/main.txt
+++ b/tests/implementation/resources/main.txt
@@ -29,13 +29,13 @@ Start Browser
 
 Start Testing
     [Documentation]  Starts the test, sets the template global variable
-    ${deployment settings} =  Get Deployment Settings  template  database_type  base_allow_repeatability
+    ${deployment settings} =  Get Deployment Settings  template  database_string  base_allow_repeatability
+    ${DB INFO}=  Get From Dictionary  ${deployment settings}  database_string
     ${TEMPLATE}=  Get From Dictionary  ${deployment settings}  template
-    ${DB TYPE}=  Get From Dictionary  ${deployment settings}  database_type
     ${REPEATABILITY}=  Get From Dictionary  ${deployment settings}  base_allow_repeatability
-    Switch To Temp Database  ${DB TYPE}  ${REPEATABILITY}
+    Switch To Temp Database  ${DB INFO}  ${REPEATABILITY}
+    Set Global variable  ${DB INFO}
     Set Global Variable  ${REPEATABILITY}
-    Set Global Variable  ${DB TYPE}
     Set Global Variable  ${TEMPLATE}
     Run Keyword If  "${HTTP_PROXY}" != "" and "${BROWSER}" == "Firefox"  Start Browser With Proxy
     ...  ELSE  Start Browser
@@ -43,6 +43,6 @@ Start Testing
 
 End Testing
     [Documentation]  Ends the test
-    Switch To Original Database  ${DB TYPE}  ${REPEATABILITY}
+    Switch To Original Database  ${DB INFO}  ${REPEATABILITY}
     Logout From Eden
     Close Browser

--- a/tests/implementation/resources/main.txt
+++ b/tests/implementation/resources/main.txt
@@ -29,8 +29,13 @@ Start Browser
 
 Start Testing
     [Documentation]  Starts the test, sets the template global variable
-    ${deployment settings} =  Get Deployment Settings  template
+    ${deployment settings} =  Get Deployment Settings  template  database_type  base_allow_repeatability
     ${TEMPLATE}=  Get From Dictionary  ${deployment settings}  template
+    ${DB TYPE}=  Get From Dictionary  ${deployment settings}  database_type
+    ${REPEATABILITY}=  Get From Dictionary  ${deployment settings}  base_allow_repeatability
+    Switch To Temp Database  ${DB TYPE}  ${REPEATABILITY}
+    Set Global Variable  ${REPEATABILITY}
+    Set Global Variable  ${DB TYPE}
     Set Global Variable  ${TEMPLATE}
     Run Keyword If  "${HTTP_PROXY}" != "" and "${BROWSER}" == "Firefox"  Start Browser With Proxy
     ...  ELSE  Start Browser
@@ -38,5 +43,6 @@ Start Testing
 
 End Testing
     [Documentation]  Ends the test
+    Switch To Original Database  ${DB TYPE}  ${REPEATABILITY}
     Logout From Eden
     Close Browser

--- a/tests/implementation/resources/main.txt
+++ b/tests/implementation/resources/main.txt
@@ -33,7 +33,7 @@ Start Testing
     ${DB INFO}=  Get From Dictionary  ${deployment settings}  database_string
     ${TEMPLATE}=  Get From Dictionary  ${deployment settings}  template
     ${REPEATABILITY}=  Get From Dictionary  ${deployment settings}  base_allow_repeatability
-    Switch To Temp Database  ${DB INFO}  ${REPEATABILITY}
+    Copy Database  ${DB INFO}  ${REPEATABILITY}
     Set Global variable  ${DB INFO}
     Set Global Variable  ${REPEATABILITY}
     Set Global Variable  ${TEMPLATE}
@@ -43,6 +43,6 @@ Start Testing
 
 End Testing
     [Documentation]  Ends the test
-    Switch To Original Database  ${DB INFO}  ${REPEATABILITY}
+    Restore Original Database  ${DB INFO}  ${REPEATABILITY}
     Logout From Eden
     Close Browser


### PR DESCRIPTION
Tests are made repeatable by executing the following steps in order:

1. A copy of the database is made during the test build as the original database might change while the test runs.
2. The original database is restored from the copy during the test tear down, thus making the tests repeatable. 

Note: The test repeatability flag is off by default and can be turned on in the 000_config.py file. Also, the repeatability feature is currently only implemented for sqlite and postgres database. 