### PR TITLE
Geonames search replaced with internal search of gis locations table.

### DIFF
--- a/static/scripts/gis/GeoExt/ux/GeoNamesSearchCombo.js
+++ b/static/scripts/gis/GeoExt/ux/GeoNamesSearchCombo.js
@@ -218,7 +218,7 @@ GeoExt.ux.GeoNamesSearchCombo = Ext.extend(Ext.form.ComboBox, {
      *  Url of the GeoNames service: http://www.GeoNames.org/export/GeoNames-search.html
      */
     /*url: 'http://ws.geonames.org/searchJSON?',*/
-    url: 'http://127.0.0.1:8000/eden/gis/search_gis_locations.html/',
+    url: 'http://'+window.location.hostname+':8000/eden/gis/search_gis_locations.html/',
 
     /** private: constructor
      */

--- a/static/scripts/gis/GeoExt/ux/GeoNamesSearchCombo.js
+++ b/static/scripts/gis/GeoExt/ux/GeoNamesSearchCombo.js
@@ -41,13 +41,13 @@ GeoExt.ux.GeoNamesSearchCombo = Ext.extend(Ext.form.ComboBox, {
      *  See http://www.dev.sencha.com/deploy/dev/docs/source/Combo.html#cfg-Ext.form.ComboBox-loadingText,
      *  default value is "Search in Geonames...".
      */
-    loadingText: 'Search in Geonames...',
+    loadingText: 'Searching locations...',
 
     /** api: config[emptyText]
      *  See http://www.dev.sencha.com/deploy/dev/docs/source/TextField.html#cfg-Ext.form.TextField-emptyText,
-     *  default value is "Search location in Geonames".
+     *  default value is "Search locations".
      */
-    emptyText: 'Search location in Geonames',
+    emptyText: 'Search locations',
 
     /** api: config[username]
      *  ``String`` Username to send with API requests. Mandatory.
@@ -217,7 +217,8 @@ GeoExt.ux.GeoNamesSearchCombo = Ext.extend(Ext.form.ComboBox, {
     /** private: property[url]
      *  Url of the GeoNames service: http://www.GeoNames.org/export/GeoNames-search.html
      */
-    url: 'http://ws.geonames.org/searchJSON?',
+    /*url: 'http://ws.geonames.org/searchJSON?',*/
+    url: 'http://127.0.0.1:8000/eden/gis/search_gis_locations.html/',
 
     /** private: constructor
      */
@@ -238,9 +239,40 @@ GeoExt.ux.GeoNamesSearchCombo = Ext.extend(Ext.form.ComboBox, {
             urlAppendString = urlAppendString + this.featureCodeString;
         }
         
+	//Query internal locations first
+	this.store = new Ext.data.Store({
+            proxy: new Ext.data.ScriptTagProxy({
+	        url: this.url,
+                method: 'GET'
+            }),
+            reader: new Ext.data.JsonReader({
+                idProperty: 'id',
+                root: "gislocations",
+                totalProperty: "totalResultsCount",
+                fields: [
+		    {
+			name:'id'
+		    },
+		    {
+			name:'fcode'
+		     },
+                    {
+                        name: 'name'
+                    },
+                    {
+                        name: 'lng'
+                    },
+                    {
+                        name: 'lat'
+                    }
+                ]
+            }) //End reader
+	}); //End store
+
+	/*if(this.store.reader.totalProperty==0){ //No internal matches
         this.store = new Ext.data.Store({
             proxy: new Ext.data.ScriptTagProxy({
-                url: this.url + urlAppendString,
+                url: 'http://ws.geonames.org/searchJSON?' + urlAppendString,
                 method: 'GET'
             }),
             baseParams: {
@@ -298,8 +330,9 @@ GeoExt.ux.GeoNamesSearchCombo = Ext.extend(Ext.form.ComboBox, {
                         name: 'adminName1'
                     }
                 ]
-            })
-        });
+	     }) //End reader
+	   });//end store
+	 }//end if*/
 
         if (this.zoom > 0) {
             this.on("select", function(combo, record, index) {


### PR DESCRIPTION
The geonames search feature has been replaced with a search of the internal DB via calling search_gis_locations() in controllers/gis.py. search_gis_locations returns a JSONP object similar in format to geonames.

Fallback on geonames if 0 results from search_gis_locations has not been implemented yet. Thus far search_gis_locations replaces geonames. One possible strategy for fallback on geonames would require some way of sending a HTTP GET request to the geonames inside the search_gis_locations method and decomposing the return JSONP into a JSON then into a dictionary. Unsure of how HTTP GET requests can be made in python - some guidance here would be most helpful.

A note on gis_location.level (gis.py lines 3804-3816): In order to make the GeoNamesSearchCombo.js zoom properly when selecting a result from the drop down list, we had to translate the level column from the gis_location table into ADM codes used by geonames. The translation is the best to our ability giving a logical ranking of levels 

Ex: Country should have a lower zoom value than a state because a country is larger than a state. Thus country is assigned the string PCL which causes the GeoNamesSearchCombo.js to set the zoom to 5. Likewise a county or a district is smaller than a state thus the zoom level for a country/district is higher.