### PR TITLE
Add option to include a title row in xls exports

### DIFF
--- a/modules/s3/s3codecs/xls.py
+++ b/modules/s3/s3codecs/xls.py
@@ -263,7 +263,11 @@ List Fields %s""" % (request.url, len(headers), len(items[0]), headers, list_fie
         for sheet in sheets:
             # Header row
             colCnt = 0
-            headerRow = sheet.row(0)
+            # Move this down if a title row will be added
+            if settings.get_xls_title_row():
+                headerRow = sheet.row(2)
+            else:
+                headerRow = sheet.row(0)
             fieldWidths = []
             id = False
             for selector in lfields:
@@ -291,25 +295,29 @@ List Fields %s""" % (request.url, len(headers), len(items[0]), headers, list_fie
                 sheet.col(writeCol).width = width
                 colCnt += 1
         # Title row
-        # - has been removed to allow columns to be easily sorted post-export.
-        # - add deployment_setting if an Org wishes a Title Row
-        # for sheet in sheets:
-            # currentRow = sheet.row(0)
-            # if colCnt > 0:
-                # sheet.write_merge(0, 0, 0, colCnt, str(title),
-                                # styleLargeHeader)
-                # currentRow.height = 500
-                # currentRow = sheet.row(1)
-                # currentRow.write(0, str(current.T("Date Exported:")), styleNotes)
-                # currentRow.write(1, request.now, styleNotes)
-                # Fix the size of the last column to display the date
-            #if 16 * COL_WIDTH_MULTIPLIER > width:
-            #    sheet.col(colCnt).width = 16 * COL_WIDTH_MULTIPLIER
+        # Adds a title row to the file if specified in the deployment settings
+        # Defaults to false
+        if settings.get_xls_title_row():
+            for sheet in sheets:
+                currentRow = sheet.row(0)
+                if colCnt > 0:
+                    sheet.write_merge(0, 0, 0, colCnt, str(title),
+                                      styleLargeHeader)
+                currentRow.height = 500
+                currentRow = sheet.row(1)
+                currentRow.write(0, str(current.T("Date Exported:")), styleNotes)
+                currentRow.write(1, request.now, styleNotes)
+                    # Fix the size of the last column to display the date
+                if 16 * COL_WIDTH_MULTIPLIER > width:
+                    sheet.col(colCnt).width = 16 * COL_WIDTH_MULTIPLIER
 
-            # Initialize counters
-            totalCols = colCnt
-        #rowCnt = 2
-        rowCnt = 0
+        # Initialize counters
+        totalCols = colCnt
+        # Move the rows down if a title row is included
+        if settings.get_xls_title_row():
+            rowCnt = 2
+        else:
+            rowCnt = 0
 
         subheading = None
         for row in rows:

--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -1495,6 +1495,12 @@ class S3Config(Storage):
                 excluded_fields_dict.get(resourcename, [])
 
         return excluded_fields
+    # -------------------------------------------------------------------------
+    # XLS Settings
+    #
+    def get_xls_title_row(self):
+        """Include a title row for XLS Exports"""
+        return self.base.get("xls_title_row", False)
 
     # -------------------------------------------------------------------------
     # UI Settings
@@ -2202,7 +2208,7 @@ class S3Config(Storage):
         """
             Authorisation setting whether to display "Submit for Approval" Button
         """
-        
+
         return self.cap.get("authorisation", True)
 
     # -------------------------------------------------------------------------

--- a/modules/templates/default/config.py
+++ b/modules/templates/default/config.py
@@ -209,6 +209,9 @@ def config(settings):
     # Location of Logo used in pdfs headers
     #settings.ui.pdf_logo = "static/img/mylogo.png"
 
+    #Uncomment to add a title row to XLS exports
+    #settings.base.xls_title_row = True
+
     # GIS (Map) settings
     # Size of the Embedded Map
     # Change this if-required for your theme


### PR DESCRIPTION
Previously, a deployment would have to uncomment/comment multiple non-adjacent lines in the codec itself if they wanted to add a title row to xls_exports. This change allows deployments to do so by specifying "settings.base.xls_title_row = True" in 000_config.py.

Summary:
- The codec in modules/s3/s3codecs/xls.py adds a title row if it is specified in the deployment settings.
- Added function in modules/s3cfg.py to access this setting.

Pull request is currently two commits because I don't know whether you want the commented option in modules/templates/000_config.py or not. The first commit adds the title row code to the codec and creates the corresponding function in s3cfg.py. The second commit adds commented lines to 000_config.py; the user would simply uncomment the line if they want to add a title row. I'll simply revert the second commit if you don't want those in the config file.

Example of a file with the title row added: https://d.maxfile.ro/forjbttqgt.xls